### PR TITLE
修复 /lyrics 读取标签的对象类型检查问题

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,7 +99,8 @@ def lyrics():
                 return lrc.standard(file_content)
     try:
         lrc_in = tags.r_lrc(path)
-        return lrc_in
+        if type(lrc_in) == str and len(lrc_in) > 0:
+            return lrc_in
     except:
         pass
     try:

--- a/mod/tags.py
+++ b/mod/tags.py
@@ -34,6 +34,13 @@ def ogg_lrc(path, lrc, read=False):
 
 
 def lrcs(path, lrc, read=False):
+    """
+    通过读取ID3和Vorbis标签查找信息
+    :param path:
+    :param lrc:
+    :param read:
+    :return:
+    """
     tag_objs = [id3_lrc, ogg_lrc]
     for tag_obj in tag_objs:
         try:
@@ -77,9 +84,13 @@ def r_lrc(path: str) -> str:
     lyrics = audio.get("lyrics", None)
     if lyrics is None:
         lyrics = lrcs(path, None, read=True)
-    if type(lyrics) == list:
-        return lyrics[0]
-    return lyrics
+    if isinstance(lyrics, list):
+        result = lyrics[0]
+    else:
+        result = lyrics
+    if not isinstance(result, str):
+        raise TypeError("The result should be a string.")
+    return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
/lyrics 读取标签的对象类型检查问题：不能处理读取出错/读取不到的情况