### PR TITLE
Update __init__.py

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -13,6 +13,13 @@ logger = logging.getLogger(__name__)
 v1_bp = Blueprint('v1', __name__, url_prefix='/api/v1')
 # Blueprint直接复制app配置项
 v1_bp.config = app.config.copy()
+
+# 添加Access-Control-Allow-Origin项以让H5客户端可以使用API
+@v1_bp.after_request
+def add_custom_headers(response):
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
+
 # 缓存逻辑
 cache_dir = './flask_cache'
 try:


### PR DESCRIPTION
添加Access-Control-Allow-Origin项以让H5客户端可以使用LrcAPI

#源代码部署情况测试以下场景：
1、使用前端访问api基于无鉴权的情况下，服务器未设置鉴权，可以正常返回歌词。
![image](https://github.com/HisAtri/LrcApi/assets/21106644/f82c2701-adb2-4e8b-b37e-eb61db2146f0)
![image](https://github.com/HisAtri/LrcApi/assets/21106644/c6f8b0aa-0d03-4923-a304-5f1b3687455a)

2、使用前端访问api基于无鉴权的情况下，服务器设置鉴权，服务器拒绝访问（这是正确回应）。
![image](https://github.com/HisAtri/LrcApi/assets/21106644/1ebe74da-4d2e-4e48-856d-2fbda275cc43)

![image](https://github.com/HisAtri/LrcApi/assets/21106644/4620c958-3cd2-4b79-89f2-74601966e41d)


其他情况暂时没有测试，所以对其他客户端的影响未知，请酌情看看是否合并分支。