### PR TITLE
Fix/searchx api requests timeout

### DIFF
--- a/mod/searchx/api.py
+++ b/mod/searchx/api.py
@@ -10,7 +10,7 @@ headers = {
 def search(title='', artist='', album='') -> list:
     try:
         url = f"http://cn.lrc.cx:880/jsonapi?title={title}&artist={artist}&album={album}&path=None&limit=1&api=lrcapi"
-        response = requests.get(url, headers=headers, timeout=30)
+        response = requests.get(url, headers=headers, timeout=15)
         return response.json()
     except Exception as e:
         print(f"LrcAPI Server - Request failed: {e}")

--- a/mod/searchx/api.py
+++ b/mod/searchx/api.py
@@ -10,7 +10,7 @@ headers = {
 def search(title='', artist='', album='') -> list:
     try:
         url = f"http://cn.lrc.cx:880/jsonapi?title={title}&artist={artist}&album={album}&path=None&limit=1&api=lrcapi"
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=30)
         return response.json()
     except Exception as e:
         print(f"LrcAPI Server - Request failed: {e}")


### PR DESCRIPTION
由于 http://cn.lrc.cx 炸了，看起来还要修一阵，我在api函数中添加了一个timeout的参数，最少的修改程序的同时至少不会卡住。