### PR TITLE
修复jsonapi接口返回格式不完全符合音流API协议问题

### DIFF
--- a/mod/searchx/kugou.py
+++ b/mod/searchx/kugou.py
@@ -89,11 +89,11 @@ async def a_search(title='', artist='', album=''):
                                 music_json_data: dict = {
                                     "title": song_name,
                                     "album": album_name,
-                                    "artists": singer_name,
+                                    "artist": singer_name,
                                     "lyrics": lrc_text,
                                     "cover": await get_cover(session, song_hash, album_id),
                                     "id": tools.calculate_md5(
-                                        f"title:{song_name};artists:{singer_name};album:{album_name}", base='dec')
+                                        f"title:{song_name};artists:{singer_name};album:{album_name}", base='decstr')
                                 }
                                 result_list.append({
                                     "data": music_json_data,

--- a/mod/searchx/migu.py
+++ b/mod/searchx/migu.py
@@ -25,11 +25,11 @@ class MiGuMusicClient:
             results.append({
                 "title": song['songName'],
                 "album": song['albumName'],
-                "artists": song['singerName'],
+                "artist": song['singerName'],
                 "lrc": lyrics,
                 "cover": song['cover'],
                 "id": tools.calculate_md5(
-                    f"title:{song['songName']};artists:{song['singerName']};album:{song['albumName']}", base='dec')
+                    f"title:{song['songName']};artists:{song['singerName']};album:{song['albumName']}", base='decstr')
             })
         return results
 

--- a/mod/searchx/netease.py
+++ b/mod/searchx/netease.py
@@ -246,11 +246,11 @@ async def search_track(session, title, artist, album):
         music_json_data: dict = {
             "title": track['title'],
             "album": track['album'],
-            "artists": track['artist'],
+            "artist": track['artist'],
             "lyrics": lyrics,
             "cover": cover_url,
             "id": tools.calculate_md5(
-                f"title:{track['title']};artists:{track['artist']};album:{track['album']}", base='dec')
+                f"title:{track['title']};artists:{track['artist']};album:{track['album']}", base='decstr')
         }
 
         result_list.append(music_json_data)

--- a/mod/tools.py
+++ b/mod/tools.py
@@ -24,6 +24,10 @@ def calculate_md5(string: str, base="hexstr"):
         # 十进制表示->int
         md5_dec = int(md5_hash.hexdigest(), 16)  # 将十六进制转换为十进制
         return md5_dec
+    elif base == "decstr":
+        # 十进制表示->int
+        md5_dec = int(md5_hash.hexdigest(), 16)  # 将十六进制转换为十进制
+        return str(md5_dec)
     elif base == "bin":
         # 二进制表示->bin
         md5_bin = format(int(md5_hash.hexdigest(), 16), '0128b')  # 将十六进制转换为二进制，补齐到128位


### PR DESCRIPTION
原jsonapi接口返回的内容不完全符合音流的规范，根据作者的指导修改后，歌词列表显示恢复正常 https://github.com/gitbobobo/StreamMusic/issues/807